### PR TITLE
Fix relative dropbox url.

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
               <td>
                 <strong>Current affiliation</strong>
               </td>
-              <td><a href="dropbox.com">Dropbox, Inc.</a></td>
+              <td><a href="http://www.dropbox.com/">Dropbox, Inc.</a></td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
Fix for broken relative url.
Live example:
http://kiddick.github.io/guidopedia/
